### PR TITLE
Allows multiple container states

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -40,7 +40,7 @@ const version = "1.11.0"
 type Options struct {
 	container        string
 	excludeContainer string
-	containerState   string
+	containerState   []string
 	timestamps       bool
 	since            time.Duration
 	context          string
@@ -60,7 +60,7 @@ type Options struct {
 
 var opts = &Options{
 	container:      ".*",
-	containerState: "running",
+	containerState: []string{stern.RUNNING, stern.WAITING},
 	tail:           -1,
 	color:          "auto",
 	template:       "",
@@ -74,7 +74,7 @@ func Run() {
 
 	cmd.Flags().StringVarP(&opts.container, "container", "c", opts.container, "Container name when multiple containers in pod")
 	cmd.Flags().StringVarP(&opts.excludeContainer, "exclude-container", "E", opts.excludeContainer, "Exclude a Container name")
-	cmd.Flags().StringVar(&opts.containerState, "container-state", opts.containerState, "If present, tail containers with status in running, waiting or terminated. Default to running.")
+	cmd.Flags().StringSliceVar(&opts.containerState, "container-state", opts.containerState, "If present, tail containers with status in running, waiting or terminated. Default to running and waiting.")
 	cmd.Flags().BoolVarP(&opts.timestamps, "timestamps", "t", opts.timestamps, "Print timestamps")
 	cmd.Flags().DurationVarP(&opts.since, "since", "s", opts.since, "Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to 48h.")
 	cmd.Flags().StringVar(&opts.context, "context", opts.context, "Kubernetes context to use. Default to current context configured in kubeconfig.")

--- a/stern/container_state.go
+++ b/stern/container_state.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-type ContainerState string
+type ContainerState []string
 
 const (
 	RUNNING    = "running"
@@ -28,20 +28,39 @@ const (
 	TERMINATED = "terminated"
 )
 
-func NewContainerState(stateConfig string) (ContainerState, error) {
-	if stateConfig == RUNNING {
-		return RUNNING, nil
-	} else if stateConfig == WAITING {
-		return WAITING, nil
-	} else if stateConfig == TERMINATED {
-		return TERMINATED, nil
+func NewContainerState(stateConfig []string) (ContainerState, error) {
+	var containerState []string
+	for _, p := range stateConfig {
+		if p == RUNNING || p == WAITING || p == TERMINATED {
+			containerState = append(containerState, p)
+		}
 	}
-
-	return "", errors.New("containerState should be one of 'running', 'waiting', or 'terminated'")
+	if len(containerState) == 0 {
+		return []string{}, errors.New("containerState should include 'running', 'waiting', or 'terminated'")
+	}
+	return containerState, nil
 }
 
 func (stateConfig ContainerState) Match(containerState v1.ContainerState) bool {
-	return (stateConfig == RUNNING && containerState.Running != nil) ||
-		(stateConfig == WAITING && containerState.Waiting != nil) ||
-		(stateConfig == TERMINATED && containerState.Terminated != nil)
+	if containerState.Running != nil && stateConfig.has(RUNNING) {
+		return true
+	}
+	if containerState.Waiting != nil && stateConfig.has(WAITING) {
+		return true
+	}
+	if containerState.Terminated != nil && stateConfig.has(TERMINATED) {
+		return true
+	}
+	return false
+}
+
+func (stateConfig ContainerState) has(state string) bool {
+	switch state {
+	case
+		RUNNING,
+		WAITING,
+		TERMINATED:
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This allows users to get any or all container states, not just one. 

Ex: `stern --container-state="running,waiting,terminated" demo`