### PR TITLE
Cleanup failed tails and replace with working ones

### DIFF
--- a/stern/main.go
+++ b/stern/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/wercker/stern/kubernetes"
@@ -58,6 +59,7 @@ func Run(ctx context.Context, config *Config) error {
 	}
 
 	tails := make(map[string]*Tail)
+	tailsMutex := sync.RWMutex{}
 	logC := make(chan string, 1024)
 
 	go func() {
@@ -74,12 +76,17 @@ func Run(ctx context.Context, config *Config) error {
 	go func() {
 		for p := range added {
 			id := p.GetID()
-			if tails[id] != nil {
-				if tails[id].Active == true {
+			tailsMutex.RLock()
+			existing := tails[id]
+			tailsMutex.RUnlock()
+			if existing != nil {
+				if existing.Active == true {
 					continue
 				} else { // cleanup failed tail to restart
+					tailsMutex.Lock()
 					tails[id].Close()
 					delete(tails, id)
+					tailsMutex.Unlock()
 				}
 			}
 			tail := NewTail(p.Namespace, p.Pod, p.Container, config.Template, &TailOptions{
@@ -90,7 +97,9 @@ func Run(ctx context.Context, config *Config) error {
 				Namespace:    config.AllNamespaces,
 				TailLines:    config.TailLines,
 			})
+			tailsMutex.Lock()
 			tails[id] = tail
+			tailsMutex.Unlock()
 			tail.Start(ctx, clientset.CoreV1().Pods(p.Namespace), logC)
 		}
 	}()
@@ -98,11 +107,16 @@ func Run(ctx context.Context, config *Config) error {
 	go func() {
 		for p := range removed {
 			id := p.GetID()
-			if tails[id] == nil {
+			tailsMutex.RLock()
+			existing := tails[id]
+			tailsMutex.RUnlock()
+			if existing == nil {
 				continue
 			}
+			tailsMutex.Lock()
 			tails[id].Close()
 			delete(tails, id)
+			tailsMutex.Unlock()
 		}
 	}()
 


### PR DESCRIPTION
Often when a new pod is added the stream will fail to open in the first
second and the tails map will be occupied with a closed tail, thus never
adding a working log. This patch will clean up closed tails to allow a
working one to be initiated.